### PR TITLE
Honor break-inside="avoid" on tbody elements

### DIFF
--- a/src/chunker/layout.js
+++ b/src/chunker/layout.js
@@ -506,6 +506,13 @@ class Layout {
 						tableRow = parentOf(node, "TR", rendered);
 					}
 					if (tableRow) {
+						// honor break-inside="avoid" in parent tbody/thead
+						let container = tableRow.parentElement;
+						if (['TBODY', 'THEAD'].includes(container.nodeName)) {
+							let styles = window.getComputedStyle(container);
+							if (styles.getPropertyValue("break-inside") === "avoid") prev = container;
+						}
+
 						// Check if the node is inside a row with a rowspan
 						const table = parentOf(tableRow, "TABLE", rendered);
 						if (table) {


### PR DESCRIPTION
Apparently tables can have multiple tbody elements (who knew?) and
marking a tbody as break-inside="avoid" is an straightforward
way to group a series of rows that are not to be split.

Works natively in Firefox, and reportedly in IE, but not in
webkit or blink based browsers.