### PR TITLE
Add an index of refs to each destination for faster lookups

### DIFF
--- a/src/chunker/layout.js
+++ b/src/chunker/layout.js
@@ -261,6 +261,13 @@ class Layout {
 			dest.appendChild(clone);
 		}
 
+		if (clone.dataset && clone.dataset.ref) {
+			if (!dest.indexOfRefs) {
+				dest.indexOfRefs = {};
+			}
+			dest.indexOfRefs[clone.dataset.ref] = clone;
+		}
+
 		let nodeHooks = this.hooks.renderNode.triggerSync(clone, node, this);
 		nodeHooks.forEach((newNode) => {
 			if (typeof newNode != "undefined") {

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -474,7 +474,11 @@ export function findElement(node, doc) {
 }
 
 export function findRef(ref, doc) {
-	return doc.querySelector(`[data-ref='${ref}']`);
+	if (doc.indexOfRefs && doc.indexOfRefs[ref]) {
+		return doc.indexOfRefs[ref];
+	} else {
+		return doc.querySelector(`[data-ref='${ref}']`);
+	}
 }
 
 export function validNode(node) {


### PR DESCRIPTION
We were attempting to render a document that had thousands of cells in a massive table, and found that it took a _very_ long time to render.

Profiling revealed that the bulk of the time was spent in running `findElement` in `layout.js`'s `append` function. `querySelector` became pretty inefficient when the document got this large. I was able to reduce load times for one of our documents from 20s to 4s by building up an index of refs while `append`ing nodes and then referencing that index later in `findRef` (in `dom.js`).

I thought I'd send this change upstream in case someone else would benefit from the performance. This version just stores the index directly on the DOM node, but I'd be happy to make any changes necessary to get this to fit in better with paged.js's conventions (or, obviously, if there are problems with this caching that I didn't anticipate).