### PR TITLE
Switch tableRow.previousSibling out for tableRow.previousElementSibling

### DIFF
--- a/src/chunker/layout.js
+++ b/src/chunker/layout.js
@@ -520,7 +520,7 @@ class Layout {
 								columnCount += parseInt(cell.getAttribute("COLSPAN") || "1");
 							}
 							if (tableRow.cells.length !== columnCount) {
-								let previousRow = tableRow.previousSibling;
+								let previousRow = tableRow.previousElementSibling;
 								let previousRowColumnCount;
 								while (previousRow !== null) {
 									previousRowColumnCount = 0;
@@ -530,7 +530,7 @@ class Layout {
 									if (previousRowColumnCount === columnCount) {
 										break;
 									}
-									previousRow = previousRow.previousSibling;
+									previousRow = previousRow.previousElementSibling;
 								}
 								if (previousRowColumnCount === columnCount) {
 									prev = previousRow;


### PR DESCRIPTION
This addresses a bug brought up by mglolenstine on Mattermost (https://mattermost.coko.foundation/coko/pl/51jsbjipdpdujbs1m1fsp3wfjw). I've attached their HTML reproducer.

The bug was that, in this chunk of code, `previousRow` ends up referencing a `#text` node instead of a `tr`. This PR fixes it by using `previousElementSibling` instead of `previousSibling`.

[long_pagedjs.zip](https://github.com/pagedjs/pagedjs/files/8764243/long_pagedjs.zip)
 