### PR TITLE
Re-select running selectors for each fragment

### DIFF
--- a/src/modules/generated-content/running-headers.js
+++ b/src/modules/generated-content/running-headers.js
@@ -87,18 +87,16 @@ class RunningHeaders extends Handler {
 	afterPageLayout(fragment) {
 		for (let name of Object.keys(this.runningSelectors)) {
 			let set = this.runningSelectors[name];
-			if (!set.first) {
-				let selected = fragment.querySelector(set.selector);
-				if (selected) {
-					// let cssVar;
-					if (set.identifier === "running") {
-						// cssVar = selected.textContent.replace(/\\([\s\S])|(["|'])/g,"\\$1$2");
-						// this.styleSheet.insertRule(`:root { --string-${name}: "${cssVar}"; }`, this.styleSheet.cssRules.length);
-						// fragment.style.setProperty(`--string-${name}`, `"${cssVar}"`);
-						set.first = selected;
-					} else {
-						console.warn(set.value + "needs css replacement");
-					}
+			let selected = fragment.querySelector(set.selector);
+			if (selected) {
+				// let cssVar;
+				if (set.identifier === "running") {
+					// cssVar = selected.textContent.replace(/\\([\s\S])|(["|'])/g,"\\$1$2");
+					// this.styleSheet.insertRule(`:root { --string-${name}: "${cssVar}"; }`, this.styleSheet.cssRules.length);
+					// fragment.style.setProperty(`--string-${name}`, `"${cssVar}"`);
+					set.first = selected;
+				} else {
+					console.warn(set.value + "needs css replacement");
 				}
 			}
 		}


### PR DESCRIPTION
The code skips over selecting elements from a fragment (page) when a running header already has a value set. This makes all content element running headers in margin boxes static.

This change makes all running selectors re-query the current page. This is required to make the code behave as described in the documentation (https://pagedjs.org/documentation/7-generated-content-in-margin-boxes/).

Fixes #103