### PR TITLE
Fixed delay script in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ However, you can add an async `before` function or return a Promise to delay the
 <script>
 	window.PagedConfig = {
 		before: () => {
-			return new Promise(resolve, reject) {
+			return new Promise((resolve, reject) => {
 				setTimeout(() => { resolve() }, 1000);
-			}
+			})
 		},
 		after: (flow) => { console.log("after", flow) },
 	};


### PR DESCRIPTION
Hey,

Note: This is an edit of my previous pull request. I proposed a fix a few days ago, but the syntax was wrong and I just noticed. Here is an update on this.

This is my first time contributing here, and I'm not so confident with my JS skills so I might have figured it out wrong somewhere. When I tried your piece of code to delay the execution of my Paged.js script, it didn't work. I added a pair of parentheses in the code and it seemed to fix it. I thought it was worth sharing.

Yann