### PR TITLE
Split target-text selector by single/double colon

### DIFF
--- a/src/modules/generated-content/target-text.js
+++ b/src/modules/generated-content/target-text.js
@@ -90,7 +90,7 @@ class TargetText extends Handler {
 	afterParsed(fragment) {
 		Object.keys(this.textTargets).forEach(name => {
 			let target = this.textTargets[name];
-			let split = target.selector.split("::");
+			let split = target.selector.split(/::?/g);
 			let query = split[0];
 			let queried = fragment.querySelectorAll(query);
 			let textContent;


### PR DESCRIPTION
Hi :wave: 

This patch fixes an issue we experienced with CSS minified by lightningcss, which shortens `::before` selectors to `:before`. This lead to the TargetText handler not finding the pseudo element's parent due to not being able to split by `::`. Fixed by splitting by `/::?/g` regex as in `TargetCounter`.