### PR TITLE
Repeat thead and colgroup when table breaks across page

### DIFF
--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -211,7 +211,23 @@ export function rebuildAncestors(node) {
 			fragment.appendChild(parent);
 		}
 		added.push(parent);
+		
+		// rebuild table headers and columns
+		if (parent.nodeName === "TABLE" && ancestor.parentElement.contains(ancestor)) {
+			let table = ancestor;
+			let thead = table.querySelector("thead");
+			if (thead) {
+				let clone = thead.cloneNode(true);
+				parent.prepend(clone);
+			}
 
+			let colgroup = table.querySelector("colgroup");
+			if (colgroup) {
+				let clone = colgroup.cloneNode(true);
+				parent.prepend(clone);
+			}
+		}
+		
 		// rebuild table rows
 		if (parent.nodeName === "TD" && ancestor.parentElement.contains(ancestor)) {
 			let td = ancestor;


### PR DESCRIPTION
Repeat thead and colgroup when table breaks across a page.

This has been an issue for us, initially using the sample RepeatTableHeadersHandler suggested elsewhere.
However the Handler method has an issue where the added header pushes the remaining page content downward, causing truncation of data where it overflows.

It also repeats the colgroup node, resolving issues with column sizing on trailing pages.

One potential issue...this method of table header repetition is non-selective, so it will _always_ apply. This may not be desirable for some cases??