### PR TITLE
Fix error if css contains a complex prelude

### DIFF
--- a/specs/media/print/print.html
+++ b/specs/media/print/print.html
@@ -11,11 +11,11 @@
 
     <script src="../../../dist/paged.polyfill.js"></script>
 
-		<style>
-			@page {
-				size: 'letter';
-				margin: 1.2in;
-			}
+    <style>
+      @page {
+        size: 'letter';
+        margin: 1.2in;
+      }
 
       section {
         color: red;
@@ -26,7 +26,13 @@
           color: green;
         }
       }
-		</style>
+
+      @media print and (min-width <= 600px) {
+        .dont-choke-on-this {
+          background-color: red;
+        }
+      }
+    </style>
 
     <style media="screen">
       @media screen {
@@ -37,15 +43,15 @@
     </style>
   </head>
 <body>
-	<section class="body-rw Chapter-rw" epub:type="bodymatter chapter">
-	<header>
-	<h1><span class="audio" id="c001s0000">Chapter 1. Loomings.</span></h1></header>
+  <section class="body-rw Chapter-rw" epub:type="bodymatter chapter">
+  <header>
+  <h1><span class="audio" id="c001s0000">Chapter 1. Loomings.</span></h1></header>
 
 
-	<p><span class="audio" id="c001s0001">Call me Ishmael.</span> <span class="audio" id="c001s0002">Some years ago—never mind how long precisely—having little or no money in my purse, and nothing particular to interest me on shore, I thought I would sail about a little and see the watery part of the world.</span> <span class="audio" id="c001s0003">It is a way I have of driving off the spleen and regulating the circulation.</span> <span class="audio" id="c001s0004">Whenever I find myself growing grim about the mouth; whenever it is a damp, drizzly November in my soul; whenever I find myself involuntarily pausing before coffin warehouses, and bringing up the rear of every funeral I meet; and especially whenever my hypos get such an upper hand of me, that it requires a strong moral principle to prevent me from deliberately stepping into the street, and methodically knocking people’s hats off—then, I account it high time to get to sea as soon as I can.</span> <span class="audio" id="c001s0005">This is my substitute for pistol and ball.</span> <span class="audio" id="c001s0006">With a philosophical flourish Cato throws himself upon his sword; I quietly take to the ship.</span> <span class="audio" id="c001s0007">There is nothing surprising in this.</span> <span class="audio" id="c001s0008">If they but knew it, almost all men in their degree, some time or other, cherish very nearly the same feelings towards the ocean with me.</span></p>
-	<p><span class="audio" id="c001p0002">There now is your insular city of the Manhattoes, belted round by wharves as Indian isles by coral reefs—commerce surrounds it with her surf. Right and left, the streets take you waterward. Its extreme downtown is the battery, where that noble mole is washed by waves, and cooled by breezes, which a few hours previous were out of sight of land. Look at the crowds of water-gazers there.</span></p>
-	<p><span class="audio" id="c001p0003">Circumambulate the city of a dreamy Sabbath afternoon. Go from Corlears Hook to Coenties Slip, and from thence, by Whitehall, northward. What do you see?—Posted like silent sentinels all around the town, stand thousands upon thousands of mortal men fixed in ocean reveries. Some leaning against the spiles; some seated upon the pier-heads; some looking over the bulwarks of ships from China; some high aloft in the rigging, as if striving to get a still better seaward peep. But these are all landsmen; of week days pent up in lath and plaster—tied to counters, nailed to benches, clinched to desks. How then is this? Are the green fields gone? What do they here?</span></p>
-	<p><span class="audio" id="c001p0004">But look! here come more crowds, pacing straight for the water, and seemingly bound for a dive. Strange! Nothing will content them but the extremest limit of the land; loitering under the shady lee of yonder warehouses will not suffice. No. They must get just as nigh the water as they possibly can without falling in. And there they stand—miles of them—leagues. Inlanders all, they come from lanes and alleys, streets and avenues—north, east, south, and west. Yet here they all unite. Tell me, does the magnetic virtue of the needles of the compasses of all those ships attract them thither?</span></p>
-	</section>
+  <p><span class="audio" id="c001s0001">Call me Ishmael.</span> <span class="audio" id="c001s0002">Some years ago—never mind how long precisely—having little or no money in my purse, and nothing particular to interest me on shore, I thought I would sail about a little and see the watery part of the world.</span> <span class="audio" id="c001s0003">It is a way I have of driving off the spleen and regulating the circulation.</span> <span class="audio" id="c001s0004">Whenever I find myself growing grim about the mouth; whenever it is a damp, drizzly November in my soul; whenever I find myself involuntarily pausing before coffin warehouses, and bringing up the rear of every funeral I meet; and especially whenever my hypos get such an upper hand of me, that it requires a strong moral principle to prevent me from deliberately stepping into the street, and methodically knocking people’s hats off—then, I account it high time to get to sea as soon as I can.</span> <span class="audio" id="c001s0005">This is my substitute for pistol and ball.</span> <span class="audio" id="c001s0006">With a philosophical flourish Cato throws himself upon his sword; I quietly take to the ship.</span> <span class="audio" id="c001s0007">There is nothing surprising in this.</span> <span class="audio" id="c001s0008">If they but knew it, almost all men in their degree, some time or other, cherish very nearly the same feelings towards the ocean with me.</span></p>
+  <p><span class="audio" id="c001p0002">There now is your insular city of the Manhattoes, belted round by wharves as Indian isles by coral reefs—commerce surrounds it with her surf. Right and left, the streets take you waterward. Its extreme downtown is the battery, where that noble mole is washed by waves, and cooled by breezes, which a few hours previous were out of sight of land. Look at the crowds of water-gazers there.</span></p>
+  <p><span class="audio" id="c001p0003">Circumambulate the city of a dreamy Sabbath afternoon. Go from Corlears Hook to Coenties Slip, and from thence, by Whitehall, northward. What do you see?—Posted like silent sentinels all around the town, stand thousands upon thousands of mortal men fixed in ocean reveries. Some leaning against the spiles; some seated upon the pier-heads; some looking over the bulwarks of ships from China; some high aloft in the rigging, as if striving to get a still better seaward peep. But these are all landsmen; of week days pent up in lath and plaster—tied to counters, nailed to benches, clinched to desks. How then is this? Are the green fields gone? What do they here?</span></p>
+  <p><span class="audio" id="c001p0004">But look! here come more crowds, pacing straight for the water, and seemingly bound for a dive. Strange! Nothing will content them but the extremest limit of the land; loitering under the shady lee of yonder warehouses will not suffice. No. They must get just as nigh the water as they possibly can without falling in. And there they stand—miles of them—leagues. Inlanders all, they come from lanes and alleys, streets and avenues—north, east, south, and west. Yet here they all unite. Tell me, does the magnetic virtue of the needles of the compasses of all those ships attract them thither?</span></p>
+  </section>
 </body>
 </html>

--- a/src/modules/paged-media/print-media.js
+++ b/src/modules/paged-media/print-media.js
@@ -51,7 +51,7 @@ class PrintMedia extends Handler {
 
 		if (typeof node.prelude === "undefined" ||
 				node.prelude.type !== "AtrulePrelude" ) {
-			return;
+			return media;
 		}
 
 		csstree.walk(node.prelude, {


### PR DESCRIPTION
I found that `print-media.js` was choking with `TypeError: Cannot read properties of undefined (reading 'includes')` because I had an `@media` css rule with a condition.

The `getMediaName` function is ignoring this node and returns undefined, but `onAtMedia` function expected it to always be an array.