### PR TITLE
Allow using pagedjs on iframes 

### DIFF
--- a/src/chunker/chunker.js
+++ b/src/chunker/chunker.js
@@ -130,7 +130,7 @@ class Chunker {
 	}
 
 	setup(renderTo) {
-		this.pagesArea = document.createElement("div");
+		this.pagesArea = renderTo.ownerDocument.createElement("div");
 		this.pagesArea.classList.add("pagedjs_pages");
 
 		if (renderTo) {
@@ -139,7 +139,7 @@ class Chunker {
 			document.querySelector("body").appendChild(this.pagesArea);
 		}
 
-		this.pageTemplate = document.createElement("template");
+		this.pageTemplate = renderTo.ownerDocument.createElement("template");
 		this.pageTemplate.innerHTML = TEMPLATE;
 
 	}

--- a/src/chunker/layout.js
+++ b/src/chunker/layout.js
@@ -93,7 +93,7 @@ class Layout {
 		this.hooks && this.hooks.onPageLayout.trigger(wrapper, prevBreakToken, this);
 
 		// Add overflow, and check that it doesn't have overflow itself.
-		this.addOverflowToPage(wrapper, breakToken, prevPage);
+		this.addOverflowToPage(wrapper, source, breakToken, prevPage);
 
 		// Footnotes may change the bounds.
 		bounds = this.element.getBoundingClientRect();
@@ -185,7 +185,7 @@ class Layout {
 			// Should the Node be a shallow or deep clone?
 			let shallow = isContainer(node);
 
-			this.append(node, wrapper, breakToken, shallow);
+			this.append(source, node, wrapper, breakToken, shallow);
 			bounds = this.element.getBoundingClientRect();
 
 			// Check whether layout has content yet.
@@ -283,6 +283,8 @@ class Layout {
 	 *
 	 * @param {element} dest
 	 *   The page content being built.
+	 * @param {source} source
+	 *   The source root DOM node
 	 * @param {breakToken} breakToken
 	 *   The current break cotent.
 	 * @param {element} alreadyRendered
@@ -290,7 +292,7 @@ class Layout {
 	 *
 	 * @returns {void}
 	 */
-	addOverflowToPage(dest, breakToken, alreadyRendered) {
+	addOverflowToPage(dest, source, breakToken, alreadyRendered) {
 
 		if (!breakToken || !breakToken.overflow.length) {
 			return;
@@ -302,7 +304,7 @@ class Layout {
 			// A handy way to dump the contents of a fragment.
 			// console.log([].map.call(overflow.content.children, e => e.outerHTML).join('\n'));
 
-			fragment = rebuildTree(overflow.node, fragment, alreadyRendered);
+			fragment = rebuildTree(overflow.node, source, fragment, alreadyRendered);
 			// Find the parent to which overflow.content should be added.
 			// Overflow.content can be a much shallower start than
 			// overflow.node, if the range end was outside of the range
@@ -331,6 +333,8 @@ class Layout {
 	/**
 	 * Add text to new page.
 	 *
+	 * @param {element} source
+	 *   The root source DOM Element
 	 * @param {element} node
 	 *   The node being appended to the destination.
 	 * @param {element} dest
@@ -345,17 +349,17 @@ class Layout {
 	 * @returns {ChildNode}
 	 *   The cloned node.
 	 */
-	append(node, dest, breakToken, shallow = true, rebuild = true) {
+	append(source, node, dest, breakToken, shallow = true, rebuild = true) {
 
 		let clone = cloneNode(node, !shallow);
 
-		if (node.parentNode && isElement(node.parentNode)) {
+		if (node.parentNode && isElement(node.parentNode) && node.parentNode != source) {
 			let parent = findElement(node.parentNode, dest);
 			// Rebuild chain
 			if (parent) {
 				parent.appendChild(clone);
 			} else if (rebuild) {
-				let fragment = rebuildTree(node.parentElement);
+				let fragment = rebuildTree(node.parentElement, source);
 				parent = findElement(node.parentNode, fragment);
 				parent.appendChild(clone);
 				dest.appendChild(fragment);
@@ -384,7 +388,8 @@ class Layout {
 		return clone;
 	}
 
-	rebuildTableFromBreakToken(breakToken, dest) {
+	// seems unused
+	rebuildTableFromBreakToken(source, breakToken, dest) {
 		if (!breakToken || !breakToken.node) {
 			return;
 		}
@@ -396,7 +401,7 @@ class Layout {
 				return;
 			}
 			while ((td = td.nextElementSibling)) {
-				this.append(td, dest, null, true);
+				this.append(source, td, dest, null, true);
 			}
 		}
 	}

--- a/src/chunker/layout.js
+++ b/src/chunker/layout.js
@@ -471,7 +471,7 @@ class Layout {
 					if (!temp.nextSibling) {
 						// We need to ensure that the previous sibling of temp is fully rendered.
 						const renderedNodeFromSource = findElement(renderedNode, source);
-						const walker = document.createTreeWalker(renderedNodeFromSource, NodeFilter.SHOW_ELEMENT);
+						const walker = source.ownersource.ownerDocument.createTreeWalker(renderedNodeFromSource, NodeFilter.SHOW_ELEMENT);
 						const lastChildOfRenderedNodeFromSource = walker.lastChild();
 						const lastChildOfRenderedNodeMatchingFromRendered = findElement(lastChildOfRenderedNodeFromSource, rendered);
 						// Check if we found that the last child in source
@@ -974,7 +974,7 @@ class Layout {
 				else {
 					// Set the start of the range and record on node or the previous element
 					// that overflow was moved.
-					range = document.createRange();
+					range = siblingRangeStart.ownerDocument.createRange();
 					if (offset) {
 						range.setStart(siblingRangeStart, offset);
 					} else {
@@ -999,7 +999,7 @@ class Layout {
 
 			if (startRemainder) {
 				// Everything including and after node is overflow.
-				range = document.createRange();
+				range = startRemainder.ownerDocument.createRange();
 				range.selectNode(startRemainder);
 				range.setEndAfter(rendered.childNodes[rendered.childNodes.length - 1]);
 
@@ -1077,7 +1077,7 @@ class Layout {
 
 		// Set the start of the range and record on node or the previous element
 		// that overflow was moved.
-		range = document.createRange();
+		range = node.ownerDocument.createRange();
 		if (offset) {
 			range.setStart(node, offset);
 		} else {

--- a/src/chunker/page.js
+++ b/src/chunker/page.js
@@ -23,7 +23,7 @@ class Page {
 	create(template, after) {
 		//let documentFragment = document.createRange().createContextualFragment( TEMPLATE );
 		//let page = documentFragment.children[0];
-		let clone = document.importNode(this.pageTemplate.content, true);
+		let clone = this.pagesArea.ownerDocument.importNode(this.pageTemplate.content, true);
 
 		let page, index;
 		if (after) {
@@ -58,7 +58,7 @@ class Page {
 	}
 
 	createWrapper() {
-		let wrapper = document.createElement("div");
+		let wrapper = this.area.ownerDocument.createElement("div");
 
 		this.area.appendChild(wrapper);
 

--- a/src/chunker/parser.js
+++ b/src/chunker/parser.js
@@ -18,7 +18,7 @@ class ContentParser {
 	}
 
 	parse(markup, mime) {
-		let range = document.createRange();
+		let range = markup.ownerDocument.createRange();
 		let fragment = range.createContextualFragment(markup);
 
 		this.addRefs(fragment);
@@ -41,7 +41,7 @@ class ContentParser {
 	}
 
 	addRefs(content) {
-		var treeWalker = document.createTreeWalker(
+		var treeWalker = content.ownerDocument.createTreeWalker(
 			content,
 			NodeFilter.SHOW_ELEMENT,
 			null,

--- a/src/modules/generated-content/target-counters.js
+++ b/src/modules/generated-content/target-counters.js
@@ -128,7 +128,7 @@ class TargetCounters extends Handler {
 					}
 
 					// force redraw
-					let el = document.querySelector(`[data-${target.variable}="${selector}"]`);
+					let el = element.ownerDocument.querySelector(`[data-${target.variable}="${selector}"]`);
 					if (el) {
 						el.style.display = "none";
 						el.clientHeight;

--- a/src/modules/paged-media/footnotes.js
+++ b/src/modules/paged-media/footnotes.js
@@ -293,7 +293,7 @@ class Footnotes extends Handler {
 			// No space to add even the footnote area
 			pageArea.style.setProperty("--pagedjs-footnotes-height", "0px");
 			// Add a wrapper as this div is removed later
-			let wrapperDiv = document.createElement("div");
+			let wrapperDiv = pageArea.ownerDocument.createElement("div");
 			wrapperDiv.appendChild(node);
 			// Push to the layout queue for the next page
 			this.needsLayout.push(wrapperDiv);
@@ -369,7 +369,7 @@ class Footnotes extends Handler {
 
 	createFootnoteCall(node) {
 		let parentElement = node.parentElement;
-		let footnoteCall = document.createElement("a");
+		let footnoteCall = node.ownerDocument.createElement("a");
 		for (const className of node.classList) {
 			footnoteCall.classList.add(`${className}`);
 		}
@@ -416,7 +416,7 @@ class Footnotes extends Handler {
 
 			if (isEntireNote) {
 				// Adjust the range to take the entire footnote.
-				let range = document.createRange();
+				let range = footnoteContainer.ownerDocument.createRange();
 				range.selectNode(footnoteContainer);
 				range.setEndAfter(footnoteContainer)
 				extracted = range.extractContents();

--- a/src/polyfill/previewer.js
+++ b/src/polyfill/previewer.js
@@ -99,7 +99,7 @@ class Previewer {
 		return template.content;
 	}
 
-	removeStyles(doc=document) {
+	removeStyles(doc=document, { remove = true } = {}) {
 		// Get all stylesheets
 		const stylesheets = Array.from(doc.querySelectorAll("link[rel='stylesheet']:not([data-pagedjs-ignore], [media~='screen'])"));
 		// Get inline styles
@@ -121,11 +121,11 @@ class Previewer {
 				if (element.nodeName === "STYLE") {
 					const obj = {};
 					obj[window.location.href] = element.textContent;
-					element.remove();
+					if (remove) element.remove();
 					return obj;
 				}
 				if (element.nodeName === "LINK") {
-					element.remove();
+					if (remove) element.remove();
 					return element.href;
 				}
 				// ignore
@@ -142,14 +142,15 @@ class Previewer {
 		}
 
 		if (!stylesheets) {
-			stylesheets = this.removeStyles();
+			let remove = (content.ownerDocument === renderTo?.ownerDocument)
+			stylesheets = this.removeStyles(content.ownerDocument, { remove });
 		}
 
-		this.polisher.setup();
+		this.polisher.setup(renderTo?.ownerDocument);
 
 		this.handlers = this.initializeHandlers();
 
-		await this.polisher.add(...stylesheets);
+		await this.polisher.addInto(renderTo?.ownerDocument, ...stylesheets);
 
 		let startTime = performance.now();
 

--- a/src/polyfill/previewer.js
+++ b/src/polyfill/previewer.js
@@ -44,6 +44,8 @@ class Previewer {
 		this.chunker.on("rendering", () => {
 			this.emit("rendering", this.chunker);
 		});
+
+		this.ready = true
 	}
 
 	initializeHandlers() {
@@ -135,6 +137,10 @@ class Previewer {
 
 	async preview(content, stylesheets, renderTo) {
 
+		if (!this.ready) {
+			throw new Error('The Previewer object cannot be reused')
+		}
+
 		await this.hooks.beforePreview.trigger(content, renderTo);
 
 		if (!content) {
@@ -149,6 +155,7 @@ class Previewer {
 		this.polisher.setup(renderTo?.ownerDocument);
 
 		this.handlers = this.initializeHandlers();
+		this.ready = false // handlers cannot be reused
 
 		await this.polisher.addInto(renderTo?.ownerDocument, ...stylesheets);
 

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -211,7 +211,7 @@ export function rebuildTableRow(node, alreadyRendered, existingChildren) {
 	return rebuilt;
 }
 
-export function rebuildTree (node, fragment, alreadyRendered) {
+export function rebuildTree (node, root, fragment, alreadyRendered) {
 	let parent, ancestor;
 	let ancestors = [];
 	let added = [];
@@ -232,7 +232,7 @@ export function rebuildTree (node, fragment, alreadyRendered) {
 			numListItems++;
 		}
 	}
-	while (element.parentNode && element.parentNode.nodeType === 1) {
+	while (element.parentNode && element.parentNode.nodeType === 1 && element.parentNode != root) {
 		ancestors.unshift(element.parentNode);
 		if (element.parentNode.tagName == "LI") {
 			numListItems++;

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -220,7 +220,7 @@ export function rebuildTree (node, fragment, alreadyRendered) {
 	let numListItems = 0;
 
 	if (!fragment) {
-		fragment = document.createDocumentFragment();
+		fragment = node.ownerDocument.createDocumentFragment();
 	}
 
 	// Gather all ancestors
@@ -363,7 +363,7 @@ export function rebuildAncestors (node) {
 	let ancestors = [];
 	let added = [];
 
-	let fragment = document.createDocumentFragment();
+	let fragment = node.ownerDocument.createDocumentFragment();
 
 	// Gather all ancestors
 	let element = node;
@@ -555,7 +555,7 @@ export function *words(node) {
 		currentLetter = currentText[currentOffset];
 		if (/^[\S\u202F\u00A0]$/.test(currentLetter) || significantWhitespaces) {
 			if (!range) {
-				range = document.createRange();
+				range = node.ownerDocument.createRange();
 				range.setStart(node, currentOffset);
 			}
 		} else {
@@ -585,7 +585,7 @@ export function *letters(wordRange) {
 
 	while(currentOffset < max) {
 		 // currentLetter = currentText[currentOffset];
-		 range = document.createRange();
+		 range = currentText.ownerDocument.createRange();
 		 range.setStart(currentText, currentOffset);
 		 range.setEnd(currentText, currentOffset+1);
 
@@ -932,8 +932,9 @@ export function nextSignificantNode(sib) {
 }
 
 export function filterTree(content, func, what) {
-	const treeWalker = document.createTreeWalker(
-		content || this.dom,
+	const contentNode = content || this.dom
+	const treeWalker = contentNode.ownerDocument.createTreeWalker(
+		contentNode,
 		what || NodeFilter.SHOW_ALL,
 		func ? { acceptNode: func } : null,
 		false

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -6,7 +6,7 @@ export function getBoundingClientRect(element) {
 	if (typeof element.getBoundingClientRect !== "undefined") {
 		rect = element.getBoundingClientRect();
 	} else {
-		let range = document.createRange();
+		let range = element.ownerDocument.createRange();
 		range.selectNode(element);
 		rect = range.getBoundingClientRect();
 	}
@@ -21,7 +21,7 @@ export function getClientRects(element) {
 	if (typeof element.getClientRects !== "undefined") {
 		rect = element.getClientRects();
 	} else {
-		let range = document.createRange();
+		let range = element.ownerDocument.createRange();
 		range.selectNode(element);
 		rect = range.getClientRects();
 	}


### PR DESCRIPTION
When using pagedjs on iframes (one iframe with the source markup and one iframe with the target pagination) pagedjs does not react well. It uses the wrong document object in many cases, remove styles from the source iframe, include the `<body>` and `<html>` tags from the source iframe (when everything is in a single document, the source markup is put in a template tag, breaking the link with the body element). 