### PR TITLE
Adding CSP Nonce Support

### DIFF
--- a/src/polisher/polisher.js
+++ b/src/polisher/polisher.js
@@ -32,9 +32,26 @@ class Polisher {
 	setup() {
 		this.base = this.insert(baseStyles);
 		this.styleEl = document.createElement("style");
+
+		const cspNonce = this.getCspNonce();
+		if (this.cspNonce) {
+			this.styleEl.setAttribute("nonce", this.cspNonce);
+		}
+
 		document.head.appendChild(this.styleEl);
 		this.styleSheet = this.styleEl.sheet;
 		return this.styleSheet;
+	}
+
+	getCspNonce() {
+		const cspNonceElement = document.querySelector("meta[name='csp-nonce']");
+		if (cspNonceElement) {
+			// The meta tag SHOULD be storing the nonce in a "nonce" attribute.
+			// Fallback to "content" if that's not the case.
+			const { nonce, content } = cspNonceElement;
+			return nonce == "" ? content : nonce;
+		}
+		return null;
 	}
 
 	async add() {
@@ -105,6 +122,11 @@ class Polisher {
 		let head = document.querySelector("head");
 		let style = document.createElement("style");
 		style.setAttribute("data-pagedjs-inserted-styles", "true");
+
+		const cspNonce = this.getCspNonce();
+		if (cspNonce) {
+			style.setAttribute("nonce", cspNonce);
+		}
 
 		style.appendChild(document.createTextNode(text));
 


### PR DESCRIPTION
In the event a site is using a Content Security Policy to lock down what styles and scripts can be used, the Polisher class was not including a nonce for any style elements it creates.  This results in those style elements being ignored by the site for violating its CSP.

The Polisher will now look for the presence of a "csp-nonce" meta element and extract the nonce to use from that.  Do to an upcoming change to how that should be stored, it will first attempt to reference the `nonce` attribute on the meta element (the new location for the nonce) before falling back to the `content` attribute (the current location for the nonce).  If found, this nonce will be added to any style element created by the Polisher.