### PR TITLE
update UUID for RFC4122 compliance

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -34,15 +34,9 @@ export function getClientRects(element) {
  * @returns {string} uuid
  */
 export function UUID() {
-	var d = new Date().getTime();
-	if (typeof performance !== "undefined" && typeof performance.now === "function") {
-		d += performance.now(); //use high-precision timer if available
-	}
-	return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function (c) {
-		var r = (d + Math.random() * 16) % 16 | 0;
-		d = Math.floor(d / 16);
-		return (c === "x" ? r : (r & 0x3 | 0x8)).toString(16);
-	});
+	return "10000000-1000-4000-8000-100000000000".replace(/[018]/g, c =>
+		(+c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> +c / 4).toString(16)
+	);
 }
 
 // From: https://hg.mozilla.org/mozilla-central/file/tip/toolkit/modules/css-selector.js#l52


### PR DESCRIPTION
UUID function hangs in a docker container and updating this function to a more compliant function that does not rely on `Math.random()` solves the issue and closes #230 