### PR TITLE
Fix: Ignore improperly parsed CSS rules

### DIFF
--- a/src/modules/paged-media/following.js
+++ b/src/modules/paged-media/following.js
@@ -27,7 +27,11 @@ class Following extends Handler {
 				}
 			});
 
-			rulelist.remove(ruleItem);
+			try {
+				rulelist.remove(ruleItem);
+			}catch(e) {
+				console.warn("Unable to remove rule (ignoring):", selector);
+			}
 		}
 	}
 


### PR DESCRIPTION
Some CSS rules can cause parsing or traversal issues. One such example:

```
div + div,
li:first-of-type
{
  color: red;
}
```

This particular ruleset fails on `rulelist.remove(ruleItem);`

Ideally, we would fix the source of this and any other problematic rules. But in case any issues like this do pop up, it's better to just move on than to fail catastrophically. This PR adds minimal error handling to one place currently causing issues. 
