### PR TITLE
Issue 238: Fix bug where script could throw an error when handling overflow

### DIFF
--- a/src/chunker/layout.js
+++ b/src/chunker/layout.js
@@ -993,7 +993,7 @@ class Layout {
 						else {
 							// Do we count this node even though it has no children?
 							// Seems to only be needed for BR.
-							if (node instanceof HTMLBRElement) {
+							if (node instanceof HTMLBRElement || node instanceof HTMLImageElement) {
 								intrinsicRight = childBounds.right;
 								intrinsicBottom = childBounds.bottom;
 							}

--- a/src/chunker/overflow.js
+++ b/src/chunker/overflow.js
@@ -20,7 +20,7 @@ class Overflow {
 			this["node"] !== otherOffset["node"]) {
 			return false;
 		}
-		if (this["offset"] && otherOffset["offset"] &&
+		if (typeof this["offset"] === "number" && typeof otherOffset["offset"] === "number" &&
 			this["offset"] !== otherOffset["offset"]) {
 			return false;
 		}


### PR DESCRIPTION
This addresses #238.

The root cause was a bug in `Overflow#equal()`. The bug could cause two Overflow objects to evaluate as equal when they weren't.

The observed bug would manifest when the following were true:
1. We are rendering a page resulting from overflow (not a forced break).
2. The page break bringing us to this page happened cleanly between elements, i.e. the text at the beginning of this page is at the beginning of its parent element in the source html.
3. One or more additional overflows are found.

When processing the latter overflow, the breakToken resulting from that overflow and the previous overflow would erroneously be considered equal and the routine would exit. This is because both breakTokens would be equal in all except their overflow.startOffset properties. Having different startOffsets should have caused them to be considered nonequal, but in this case, because one of the startOffsets happenend to be 0, Overflow.equal() would skip comparing them.