### PR TITLE
Fix link to pagedjs-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Examples:
 
 ### CLI
 
-Command line interface to render out PDFs of HTML files using Puppeteer: [https://gitlab.pagedmedia.org/tools/pagedjs-cli](https://gitlab.pagedmedia.org/tools/pagedjs-cli).
+Command line interface to render out PDFs of HTML files using Puppeteer: [https://github.com/pagedjs/pagedjs-cli/](https://github.com/pagedjs/pagedjs-cli/)
 
 ## Modules
 


### PR DESCRIPTION
Was linked to gitlab.pagedmedia.org, which no longer exists and has been moved to github, see recent comment by pagedmedia contributor:

https://github.com/pagedjs/pagedjs/issues/299#issuecomment-3281222872