### PR TITLE
Bugfix pagedjs_margin-content display property in marginalia content

### DIFF
--- a/src/modules/paged-media/atpage.js
+++ b/src/modules/paged-media/atpage.js
@@ -1102,9 +1102,10 @@ class AtPage extends Handler {
 				enter: (node, item, list) => {
 					if (node.property !== "content") {
 						list.remove(item);
+						return;
 					}
 
-					else if (
+					if (
 						node.value.children &&
 						node.value.children.first().name === "none"
 					) {


### PR DESCRIPTION
PR intends to address two bugs where `.pagedjs_margin-content` is incorrectly set to `display: none;`.
- First, this occurs when another property in the `@page` margin (such as border, text-decoration, pointer-events, cursor, etc.) has a value of `none`.
- Second, this occurs due to a scoping issue where variable `displayNone` should be scoped to the margin box but is instead scoped to the page.  So, an earlier margin having `content: none;` or impacted by the first bug will cause `.pagedjs_margin-content` to have `display: none;' for all subsequent margin boxes on that page.