### PR TITLE
fix(chunker): propagate render errors instead of silently swallowing

### DIFF
--- a/src/chunker/chunker.js
+++ b/src/chunker/chunker.js
@@ -294,6 +294,10 @@ class Chunker {
 			rendered = await this.render(parsed, this.breakToken);
 		}
 
+		if (rendered && rendered.value instanceof Error) {
+			throw rendered.value;
+		}
+
 		this.rendered = true;
 		this.pagesArea.style.setProperty("--pagedjs-page-count", this.total);
 

--- a/src/chunker/page.js
+++ b/src/chunker/page.js
@@ -157,6 +157,11 @@ class Page {
 			breakToken,
 			prevPage,
 		);
+
+		if (renderResult && renderResult.error) {
+			throw renderResult.error;
+		}
+
 		let newBreakToken = renderResult.breakToken;
 
 		if (breakToken && newBreakToken && breakToken.equals(newBreakToken)) {
@@ -188,6 +193,11 @@ class Page {
 			contents,
 			breakToken,
 		);
+
+		if (renderResult && renderResult.error) {
+			throw renderResult.error;
+		}
+
 		let newBreakToken = renderResult.breakToken;
 
 		this.endToken = newBreakToken;


### PR DESCRIPTION
## Problem

Paged.js currently swallows errors during layout/rendering operations. When `layoutMethod.renderTo()` encounters an error, it returns an object with an `error` property, but the calling code in `Page.layout()` and `Page.append()` immediately accesses `renderResult.breakToken` without checking for errors first.

Similarly, in the main Chunker flow, when `rendered.value` contains an Error instance, the code proceeds to set `this.rendered = true` without surfacing the error.

This leads to silent failures where:
- Pagination appears to complete successfully
- The resulting PDF is incomplete or malformed
- Users have no indication that something went wrong
- Debugging requires deep internal knowledge of Paged.js internals

## Solution

Add explicit error propagation at three critical points:

1. **Page.layout()**: Check `renderResult.error` after `renderTo()` and throw if present
2. **Page.append()**: Same check for the append flow
3. **Chunker flow**: Check if `rendered.value instanceof Error` after the render loop and throw before marking as complete

## Changes

- `src/chunker/page.js`: Added error checks after both `renderTo()` calls
- `src/chunker/chunker.js`: Added error check in the main render flow

## Impact

This is a fail-fast improvement that helps users detect pagination problems early rather than discovering incomplete PDFs later. It's backward compatible for successful renders but will now properly throw for failed ones.

## Testing

This patch was extracted from production use in a book PDF generation pipeline where it successfully caught silent layout failures that were previously producing incomplete documents (226 pages instead of 338).
