### PR TITLE
Add Accept: text/css header to Polisher request

### DIFF
--- a/src/polisher/polisher.js
+++ b/src/polisher/polisher.js
@@ -71,7 +71,11 @@ class Polisher {
 				}
 			} else {
 				urls.push(source);
-				f = request(source).then((response) => response.text());
+				f = request(source, {
+          headers: {
+            Accept: "text/css",
+          }
+        }).then((response) => response.text());
 			}
 
 			fetched.push(f);


### PR DESCRIPTION
Send `Accept: text/css` header when fetching the stylesheet source.

Fixes #331 