### PR TITLE
Validate base URL before replacing URLs

### DIFF
--- a/src/polisher/sheet.js
+++ b/src/polisher/sheet.js
@@ -208,6 +208,10 @@ class Sheet {
 	 * @param {Object} ast - CSS AST.
 	 */
 	replaceUrls(ast) {
+		if (!URL.canParse("", this.url)) {
+			// skip replacing urls if this.url is invalid as a base url
+			return;
+		}
 		csstree.walk(ast, {
 			visit: "Url",
 			enter: (node) => {


### PR DESCRIPTION
This modifies `replaceUrls` to skip replacement when the current page href is an invalid base url.

The basic problem is that this construction throws an Invalid URL error:

```js
new URL("relative-path", new URL("about:blank"))
```

This situation occurs in `replaceUrls` when running in an iframe with the src attribute unset. In this scenario, `window.location.href` is equal to `about:blank` or `about:srcdoc`. This is the code path that results in the execution of the above simplification:

https://github.com/pagedjs/pagedjs/blob/6b0ff8089f472a17247e44671da93d2d931e656e/src/polisher/sheet.js#L37

https://github.com/pagedjs/pagedjs/blob/6b0ff8089f472a17247e44671da93d2d931e656e/src/polisher/sheet.js#L223

Creating an iframe with src unset provides the following advantages: 1. you can set any content you want via script (doesn't load anything from the server by default), 2. cookie and CSP resolution falls back to the permissions of the window that contains the iframe, no authentication setup and no additional CSP rules are required.

<s>There are [a number of `about:*` pages](https://superuser.com/a/1437882/158158) so this tests for any of them.</s> This generically validates that `this.url` is a valid base url when `replaceUrls` is called, and skips replacement if validation fails.

Fixes #318. See also #334.