### PR TITLE
Fix nth-child selectors with + in An+B being treated as adjacent sibling combinators

### DIFF
--- a/src/modules/paged-media/following.js
+++ b/src/modules/paged-media/following.js
@@ -27,7 +27,7 @@ class Following extends Handler {
 
 	onRule(ruleNode, ruleItem, rulelist) {
 		let selector = csstree.generate(ruleNode.prelude);
-		if (selector.match(/\+/)) {
+				if (selector.replace(/:nth[-\w]*\([^)]*\)/g, '').match(/\+/)) {
 			let declarations = csstree.generate(ruleNode.block);
 			declarations = declarations.replace(/[{}]/g, "");
 


### PR DESCRIPTION
## Problem

`nth-child()` / `nth-last-child()` selectors that contain `+` in the An+B expression (e.g. `:nth-last-child(-n+3)`) are silently dropped after Paged.js renders. No error or warning is emitted.

## Reproduction

```css
/* Dropped — contains + inside nth-last-child() */
.table td:nth-last-child(-n+3) { text-align: right; }

/* Preserved — no + in selector */
.table tr:nth-child(even) { background: #f5f5f5; }
```

After Paged.js renders, the first rule is completely absent from the output.

## Root cause

`src/modules/paged-media/following.js` line 30 uses `selector.match(/\+/)` to detect adjacent sibling combinators. This regex matches **any** `+` character, including the `+` inside the An+B microsyntax like `:nth-last-child(-n+3)`. The handler then incorrectly removes and rewrites the rule.

## Fix

Strip `:nth-*()` pseudo-class arguments before testing for the `+` combinator:

```js
// Before
if (selector.match(/\+/)) {

// After
if (selector.replace(/:nth[-\w]*\([^)]*\)/g, '').match(/\+/)) {
```

## Test matrix

| Selector | Before | After |
|---|---|---|
| `td:nth-last-child(-n+3)` | Dropped (false positive) | Preserved |
| `tr + tr` | Handled correctly | Handled correctly |
| `:has(> strong + code)` | Handled correctly | Handled correctly |
| `tr:nth-child(even)` | Preserved | Preserved |