### PR TITLE
Fix NthOfType Handler splitting selectors

### DIFF
--- a/src/modules/paged-media/following.js
+++ b/src/modules/paged-media/following.js
@@ -33,17 +33,16 @@ class Following extends Handler {
 
 			let uuid = "following-" + UUID();
 
-			selector.split(",").forEach((s) => {
-				if (!this.selectors[s]) {
-					this.selectors[s] = [uuid, declarations];
-				} else {
-					this.selectors[s][1] = `${this.selectors[s][1]};${declarations}`;
-				}
-			});
+			if (!this.selectors[selector]) {
+				this.selectors[selector] = [uuid, declarations];
+			} else {
+				this.selectors[selector][1] = `${this.selectors[selector][1]};${declarations}`;
+			}
 
 			rulelist.remove(ruleItem);
 		}
 	}
+
 	afterParsed(parsed) {
 		this.processSelectors(parsed, this.selectors);
 	}

--- a/src/modules/paged-media/nth-of-type.js
+++ b/src/modules/paged-media/nth-of-type.js
@@ -43,13 +43,11 @@ class NthOfType extends Handler {
 
 			let uuid = "nth-of-type-" + UUID();
 
-			selector.split(",").forEach((s) => {
-				if (!this.selectors[s]) {
-					this.selectors[s] = [uuid, declarations];
-				} else {
-					this.selectors[s][1] = `${this.selectors[s][1]};${declarations}`;
-				}
-			});
+			if (!this.selectors[selector]) {
+				this.selectors[selector] = [uuid, declarations];
+			} else {
+				this.selectors[selector][1] = `${this.selectors[selector][1]};${declarations}`;
+			}
 
 			rulelist.remove(ruleItem); // Remove original pseudo selector rule
 		}


### PR DESCRIPTION
This PR does fix the compatibility with the following CSS rules:
```css
.prose :where(h4):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
  color: #FFF;
}
.prose :where(h3):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
  color: #FFF;
}

.prose :where(blockquote p:first-of-type):not(:where([class~="not-prose"], [class~="not-prose"] *))::before,
.foo :where(blockquote p:first-of-type):not(:where([class~="not-prose"], [class~="not-prose"] *))::before,
.bar :where(blockquote p:first-of-type):not(:where([class~="not-prose"], [class~="not-prose"] *))::before {
  content: open-quote;
}

.prose :where(blockquote p:last-of-type):not(:where([class~="not-prose"], [class~="not-prose"] *))::after {
  content: close-quote;
}
```

The selector is split for no reason, breaking it. I removed the splitting, essentially keeping the selector as it is. This does fix my issues with using PagedJS with Tailwind v4 after Vite built the assets.

Related: #166, #269