### PR TITLE
fix(chunker): skip cross-origin stylesheets in recordRulesToDisable

### DIFF
--- a/src/chunker/chunker.js
+++ b/src/chunker/chunker.js
@@ -176,8 +176,13 @@ class Chunker {
 	recordRulesToDisable() {
 		for (var i in document.styleSheets) {
 			let sheet = document.styleSheets[i];
-			for (var j in sheet.cssRules) {
-				let rule = sheet.cssRules.item(j);
+			// Cross-origin stylesheets (e.g. fonts loaded via CDN) throw
+			// SecurityError when cssRules is read.  Skip those sheets.
+			let rules;
+			try { rules = sheet.cssRules; } catch (e) { continue; }
+			if (!rules) continue;
+			for (var j in rules) {
+				let rule = rules.item(j);
 				if (rule && rule.style) {
 					for (var k in this.rulesToDisable) {
 						let skip = false;
@@ -265,7 +270,12 @@ class Chunker {
 
 		if (content) {
 			this.recordRulesToDisable();
-			this.disableRules(content);
+			// `content` may be a raw HTML/XML string (Previewer.preview accepts
+			// either Element/Document or string).  disableRules / enableRules
+			// call querySelectorAll on it, which only works on a DOM node.
+			if (typeof content.querySelectorAll === "function") {
+				this.disableRules(content);
+			}
 		}
 
 		parsed = new ContentParser(content);
@@ -301,7 +311,9 @@ class Chunker {
 
 		this.emit("rendered", this.pages);
 
-		this.enableRules(content);
+		if (content && typeof content.querySelectorAll === "function") {
+			this.enableRules(content);
+		}
 
 		return this;
 	}


### PR DESCRIPTION
## Problem

`Chunker.recordRulesToDisable` (`src/chunker/chunker.js:176`) iterates `document.styleSheets` and reads `sheet.cssRules` directly:

```js
recordRulesToDisable() {
  for (var i in document.styleSheets) {
    let sheet = document.styleSheets[i];
    for (var j in sheet.cssRules) {
      let rule = sheet.cssRules.item(j);
      ...
    }
  }
}
```

`document.styleSheets` includes every stylesheet on the page, including ones loaded from a different origin (Google Fonts CDN, etc.). Reading `cssRules` on a cross-origin sheet throws:

> `DOMException: CSSStyleSheet.cssRules getter: Not allowed to access cross-origin stylesheet`

The exception aborts the entire `flow()` call before any page is laid out — Paged.js silently produces zero `.pagedjs_page` elements.

## Fix

Wrap the `cssRules` read in `try/catch` and skip the sheet on failure:

```js
let rules;
try { rules = sheet.cssRules; } catch (e) { continue; }
if (!rules) continue;
for (var j in rules) {
  let rule = rules.item(j);
  ...
}
```

This matches the defensive pattern used elsewhere in the codebase for accessing potentially-restricted DOM APIs.

## Repro

Any document that loads Google Fonts (or any cross-origin stylesheet) via `<link rel="stylesheet">` triggers the exception in Firefox and Chrome's strict modes. The repro is environmental — no special markup needed beyond a single CDN-hosted stylesheet.

## Notes

This is a separate concern from #341 (Following handler with functional pseudo-classes); both surfaced in the same downstream project but neither depends on the other.