### PR TITLE
fix(layout): pin column width via inline style instead of element.width

### DIFF
--- a/src/chunker/layout.js
+++ b/src/chunker/layout.js
@@ -1546,12 +1546,14 @@ class Layout {
 				}
 			}
 
-			// Get the columns widths and make them attributes so removal of
-			// overflow doesn't do strange things - they may be affecting
-			// widths on this page.
+			// Get the columns widths and pin them as inline styles so removal
+			// of overflow doesn't do strange things - they may be affecting
+			// widths on this page.  (Setting `.width` directly throws on
+			// elements that expose it as a read-only DOM property — most
+			// non-replaced elements in Firefox.)
 			Array.from(check.parentElement.children).forEach((childNode) => {
 				let style = getComputedStyle(childNode);
-				childNode.width = style.width;
+				try { childNode.style.width = style.width; } catch (e) { /* ignore */ }
 			});
 
 			if (


### PR DESCRIPTION
## Problem

`Layout.findOverflow` (`src/chunker/layout.js`) preserves the computed widths of the current row's columns before removing overflow content:

```js
Array.from(check.parentElement.children).forEach((childNode) => {
  let style = getComputedStyle(childNode);
  childNode.width = style.width;
});
```

`childNode.width = ...` writes a JavaScript property whose semantics depend on the element type:

- For replaced elements (`<img>`, `<canvas>`, `<video>`) it works — `.width` is a writable DOM IDL attribute.
- For most other elements (`<div>`, `<p>`, `<span>`, ...) the prototype exposes only a read-only getter (or no `.width` at all). Firefox throws:
  > `TypeError: setting getter-only property "width"`
  Chrome silently writes a custom JS property that has no rendering effect.

In both browsers the call is the wrong primitive for the comment's intent ("make them attributes so removal of overflow doesn't do strange things"). In Firefox it also crashes the whole layout run before any page is laid out.

## Fix

Pin the value as an inline CSS style — that's what the comment is really asking for, and it works on every element type:

```js
Array.from(check.parentElement.children).forEach((childNode) => {
  let style = getComputedStyle(childNode);
  try { childNode.style.width = style.width; } catch (e) { /* ignore */ }
});
```

`try/catch` is a defence-in-depth guard for elements with unusual `style` access (SVG sub-elements with read-only `style` shorthands have surfaced in unrelated tracker reports).

## Repro

Any document with overflowing text inside a regular block element triggers the read-only-width error in Firefox. The repro is environmental — no special markup needed beyond content that overflows a page region.

## Notes

Independent of #341 (Following handler) and #342 (recordRulesToDisable / disableRules guards). All three crashes surfaced together in the same downstream Markdown→PDF embedder, but each is its own concern.