### PR TITLE
Fix documentation links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Paged.js is an open-source library to display paginated content in the browser a
 
 It contains a set of handlers for CSS transformations and fragmented layout which polyfill the [Paged Media](https://www.w3.org/TR/css-page-3/) and [Generated Content](https://www.w3.org/TR/css-gcpm-3/) CSS modules, along with hooks to create new handlers for custom properties.
 
-The currently supported properties can be found on [the pagedjs website](https://pagedjs.org/documentation/cheatsheet/).
+The currently supported properties can be found on [the pagedjs website](https://pagedjs.org/en/documentation/cheatsheet/).
 
-A quick overview to getting started with Paged Media CSS and Paged.js is available on [pagedjs.org/documentation](https://pagedjs.org/documentation/).
+A quick overview to getting started with Paged Media CSS and Paged.js is available on [pagedjs.org/en/documentation](https://pagedjs.org/en/documentation/).
 
 ## NPM Module
 ```sh


### PR DESCRIPTION
Updated links in README.md to use the '/en/' prefix for documentation, fixing broken links.