### PR TITLE
Fix three overflow-detection defects that abort or silently truncate pagination

### DIFF
--- a/src/chunker/layout.js
+++ b/src/chunker/layout.js
@@ -856,13 +856,19 @@ class Layout {
 	 */
 	hasOverflow(element, bounds = this.bounds) {
 		let constrainingElement = element && element.parentNode; // this gets the element, instead of the wrapper for the width workaround
-		if (constrainingElement.classList.contains("pagedjs_page_content")) {
-			constrainingElement = element;
-		}
 		let { width, height } = element.getBoundingClientRect();
-		let scrollWidth = constrainingElement ? constrainingElement.scrollWidth : 0;
+		// .pagedjs_page_content is the multi-column box, so content that spills
+		// past the page shows up in its scrollWidth and not in `element`'s,
+		// which stays at the page width. #171 made this measure `element`
+		// whenever the parent is the content area — exactly the case where the
+		// spill is only visible on the parent — so a page could scroll to
+		// 13760px while hasOverflow() reported false. Take the larger of the
+		// two, keeping the workaround #171 wanted without losing that signal.
+		let scrollWidth = constrainingElement
+			? Math.max(constrainingElement.scrollWidth, element.scrollWidth)
+			: 0;
 		let scrollHeight = constrainingElement
-			? constrainingElement.scrollHeight
+			? Math.max(constrainingElement.scrollHeight, element.scrollHeight)
 			: 0;
 		return (
 			Math.max(Math.ceil(width), scrollWidth) > Math.ceil(bounds.width) ||

--- a/src/chunker/layout.js
+++ b/src/chunker/layout.js
@@ -1367,8 +1367,15 @@ class Layout {
 		} else {
 			position = position.parentElement;
 		}
+		// The `position !== rendered` guard is evaluated before `position` moves
+		// up, so the last iteration tags `rendered` itself. findOverflow() bails
+		// out on a tagged root, so the page then reports no overflow at all even
+		// while hasOverflow() is true, and its remaining content is never split.
 		while (!position.nextElementSibling && position !== rendered) {
 			position = position.parentElement;
+			if (position === rendered) {
+				break;
+			}
 			position.dataset.overflowTagged = true;
 		}
 

--- a/src/chunker/layout.js
+++ b/src/chunker/layout.js
@@ -348,6 +348,19 @@ class Layout {
 			// console.log([].map.call(overflow.content.children, e => e.outerHTML).join('\n'));
 
 			fragment = rebuildTree(overflow.node, fragment, alreadyRendered);
+
+			// processOverflowResult pushes an Overflow into breakToken.overflow
+			// before it decides whether to extract it: when its loop detection
+			// fires ("Stop removal if we are in a loop") it returns early and
+			// leaves `content` unset. Such an entry has nothing to contribute
+			// here, and dereferencing it aborts the whole render. Skip it, as
+			// the forced-break check below already does for `firstOverflow`.
+			// The tree is rebuilt first so `fragment` is always defined for the
+			// data-ref pass after this loop.
+			if (!overflow.content) {
+				return;
+			}
+
 			// Find the parent to which overflow.content should be added.
 			// Overflow.content can be a much shallower start than
 			// overflow.node, if the range end was outside of the range


### PR DESCRIPTION
Three independent defects in overflow detection, found while evaluating an
upgrade from v0.4.3 to `main` (`6b0ff80`) for a production print path. All
three are in the `layout.js` rewrites from #171 and #196; none exists in
v0.4.3.

**These are prerequisites, not a cure.** The document that led me here still
loses rows with all three applied, for reasons I could not fix without
reworking the range-finding — filed separately as #351. I have kept the two
apart so this PR stays reviewable.

## 1. A render-ending crash on an overflow with no content

`processOverflowResult()` pushes each `Overflow` into `breakToken.overflow`
*before* it decides whether to extract it. When its loop detection fires —

```js
// Stop removal if we are in a loop
if (breakToken.equals(prevBreakToken)) {
    return;
}
```

— it returns early and leaves that entry's `content` unset.
`addOverflowToPage()` then walks every entry and dereferences `content`:

```
TypeError: Cannot read properties of undefined (reading 'childNodes')
    at Layout.addOverflowNodes
    at Layout.addOverflowToPage
    at Layout.renderTo
    at Page.layout
    at Chunker.layout
    at async Chunker.renderAsync
```

Thrown out of `renderAsync`, this aborts pagination and truncates the document
from that page on.

The fix skips entries carrying no content — which is what the forced-break
check further down the same function already does for `firstOverflow`. The
guard sits after `rebuildTree()` so `fragment` is still defined for the
`data-ref` pass that follows the loop.

## 2. The page tags its own content root

The ancestor walk that marks nodes already covered by an overflow range tests
`position !== rendered` in its loop condition, but only moves `position` up
afterwards — so the final iteration tags `rendered`, the page content root,
itself.

`findOverflow()` returns early for a tagged root:

```js
if (!this.hasOverflow(rendered, bounds) || rendered.dataset.overflowTagged) {
    return;
}
```

From that moment the page reports no overflow at all, while `hasOverflow()` is
still true and its content area still scrolls well past the page box. The
cleanup pass in `addOverflowToPage()` cannot undo it either: it clears the tag
with `querySelectorAll()`, which never matches the root element it is called
on.

Observed on the table in #351 — every page tagged its own root on the first
pass, after which no further break was ever found.

## 3. Overflow measured on the wrapper instead of the column box

Paged.js finds breaks by making the page a multi-column box with a ~1000px
column gap and detecting what the browser pushed into the off-page column. That
spill shows up in the `scrollWidth` of `.pagedjs_page_content`, the element
carrying the column properties.

v0.4.3 measured exactly that, `element.parentNode`. #171 added:

```js
let constrainingElement = element && element.parentNode;
if (constrainingElement.classList.contains("pagedjs_page_content")) {
    constrainingElement = element;
}
```

which measures the wrapper *inside* it whenever the parent is the content
area — precisely the case where only the parent carries the signal. The
wrapper's own `scrollWidth` stays at the page width, so the spilled column
becomes invisible: a page whose content area had scrolled to **13760px**
against a **1009px** bound reported `hasOverflow() === false`,
`findBreakToken()` returned `undefined`, and the chunker ended with the
remainder left on that page.

I have taken the larger of the two rather than reverting, so whatever #171 was
working around still holds while the column signal survives. If that branch was
added for a case I have not reproduced, I would rather hear about it than guess
— happy to adjust.

## Testing

Verified by printing to PDF and reading the result back with `pdftotext`,
against both this branch and v0.4.3:

- A 140-row table with a `<thead>`: 6 pages, all 140 rows, header repeated on
  each — matching v0.4.3 exactly.
- The tall-cell table from #351: no longer throws, though it still loses rows
  for the reason described there.

I did not add a spec. The failing documents are pagination-shaped rather than
assertion-shaped, and the honest test for them is a PDF comparison of the kind
`npm run specs` already does — I would rather follow your steer on where such a
case belongs than guess at it. Glad to add one.

Note for measuring any of this: `chrome --print-to-pdf` snapshots before
Paged.js has finished even with `--virtual-time-budget`, and returns a blank
one-page PDF for a document that renders 29 sheets. Poll until the
`.pagedjs_page` count is stable, then print.
