### PR TITLE
Fix inline styles incorrectly marking visible elements as undisplayed

### DIFF
--- a/specs/filters/undisplayed/inline-styles.html
+++ b/specs/filters/undisplayed/inline-styles.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Visible inline styles preserve chapter page breaks</title>
+  <style>
+    @page { size: A5; margin: 20mm; }
+    .chapter { break-before: page; }
+  </style>
+</head>
+<body>
+  <section class="chapter" style="padding: 24px; color: red;">
+    Chapter one
+  </section>
+  <section class="chapter">
+    Chapter two
+  </section>
+  <script src="../../../dist/paged.polyfill.js"></script>
+</body>
+</html>

--- a/specs/filters/undisplayed/inline-styles.spec.js
+++ b/specs/filters/undisplayed/inline-styles.spec.js
@@ -1,0 +1,23 @@
+const TIMEOUT = 10000;
+
+describe("visible inline styles", () => {
+	let page;
+
+	beforeAll(async () => {
+		page = await loadPage("filters/undisplayed/inline-styles.html");
+		return page.rendered;
+	}, TIMEOUT);
+
+	afterAll(async () => {
+		if (!DEBUG) {
+			await page.close();
+		}
+	});
+
+	it("keeps consecutive chapters on separate pages", async () => {
+		const chapters = await page.$$eval(".pagedjs_page", (pages) => pages.map((sheet) =>
+			Array.from(sheet.querySelectorAll(".chapter"), (chapter) => chapter.textContent.trim())
+		));
+		expect(chapters).toEqual([["Chapter one"], ["Chapter two"]]);
+	});
+});

--- a/src/modules/filters/undisplayed.js
+++ b/src/modules/filters/undisplayed.js
@@ -77,7 +77,7 @@ class UndisplayedFilter extends Handler {
 		const styledElements = content.querySelectorAll("[style]");
 		for (let i = 0; i < styledElements.length; i++) {
 			const element = styledElements[i];
-			if (this.removable(element)) {
+			if (element.style.display === "none") {
 				element.dataset.undisplayed = "undisplayed";
 			}
 		}

--- a/src/modules/filters/undisplayed.test.js
+++ b/src/modules/filters/undisplayed.test.js
@@ -1,0 +1,40 @@
+import csstree from "css-tree";
+import UndisplayedFilter from "./undisplayed.js";
+
+describe("UndisplayedFilter", () => {
+	function filterElement(style, css) {
+		const content = document.createElement("div");
+		const element = document.createElement("section");
+		element.className = "chapter";
+		if (style !== undefined) {
+			element.setAttribute("style", style);
+		}
+		content.appendChild(element);
+		const filter = new UndisplayedFilter();
+		if (css) {
+			const rule = csstree.parse(css).children.first();
+			filter.onDeclaration(rule.block.children.first(), null, null, { ruleNode: rule });
+		}
+		filter.filter(content);
+		return element;
+	}
+
+	it.each(["", "padding: 24px", "color: red", "display: block"])(
+		"does not mark visible inline styles as undisplayed: %s",
+		(style) => {
+			expect(filterElement(style).hasAttribute("data-undisplayed")).toBe(false);
+		}
+	);
+
+	it("marks inline display: none as undisplayed", () => {
+		expect(filterElement("display: none").dataset.undisplayed).toBe("undisplayed");
+	});
+
+	it.each([undefined, "padding: 24px"])("preserves stylesheet display: none with inline style %s", (style) => {
+		expect(filterElement(style, ".chapter { display: none }").dataset.undisplayed).toBe("undisplayed");
+	});
+
+	it("preserves an inline display override of a normal stylesheet rule", () => {
+		expect(filterElement("display: block", ".chapter { display: none }").hasAttribute("data-undisplayed")).toBe(false);
+	});
+});


### PR DESCRIPTION
## Visible inline styles can remove a page break

Fixes #311. Adding `style="padding: 24px; color: red"` to the first chapter should not change where the second chapter starts. With this plain HTML, however, both chapters end up on one page:

```html
<style>
  @page { size: A5; margin: 20mm; }
  .chapter { break-before: page; }
</style>

<section class="chapter" style="padding: 24px; color: red;">
  Chapter one
</section>
<section class="chapter">
  Chapter two
</section>
```

| Rendering of this fixture | Page 1 | Page 2 |
| --- | --- | --- |
| Before this fix | Chapter one + Chapter two | Missing |
| After this fix (expected) | Chapter one | Chapter two |

This reproduces in Chromium and WebKit. The complete fixture is included in `specs/filters/undisplayed/inline-styles.html`; it requires no framework or editor.

## Why this happens

`UndisplayedFilter` loops over every element with a `style` attribute and calls `removable()`. For the first section above:

```js
element.style.display === ""; // No inline display declaration.
this.removable(element) === true;
```

The filter therefore incorrectly adds `data-undisplayed="undisplayed"` to a visible chapter. PagedJS skips elements with that marker when looking for preceding displayed content (`displayedElementBefore`). In this fixture, that causes the following chapter's page break to be lost.

## Why the fix belongs in the inline-style loop

The earlier candidate in [40cc1c8](https://github.com/pagedjs/pagedjs/commit/40cc1c83d08da42022ba7f23246bdc194c51922d), included in #319, changes the shared helper to return true only for inline `display: none`:

```js
removable(element) {
  return element.style?.display === "none";
}
```

That addresses the visible chapter above, but the same helper also serves the stylesheet-rule path. Consider:

```html
<style>.hidden { display: none; }</style>
<section class="hidden">Hidden content</section>
```

Here, `element.style.display` is still `""`: it reads inline declarations, not stylesheet rules. The stylesheet path has already found `display: none`, but the proposed helper returns false, preventing this hidden element from receiving the marker. CSS still hides it; the regression is in PagedJS's classification for traversal.

This PR instead changes only the inline-style loop:

```diff
- if (this.removable(element)) {
+ if (element.style.display === "none") {
    element.dataset.undisplayed = "undisplayed";
  }
```

The stylesheet path keeps its existing behavior, including handling inline display overrides. The production change is one line, with tests for both paths.

This is a narrower alternative to the filter change in #319, not a replacement for its other changes. The overlapping changes need reconciliation when merging. The diagnosis also matches the [maintainer's comment on #311](https://github.com/pagedjs/pagedjs/issues/311#issuecomment-3950912635).

## Validation and limits

- New unit cases against unchanged upstream: **3 failed, 5 passed**. After the fix: **all 9 unit tests pass across 2 suites**.
- Built with Node 20 and checked this fixture directly in **Chromium and WebKit**, waiting for `PagedConfig.after`: one page before, two pages after, with chapter text checked on each page. A regression spec using the repository's existing `loadPage`/Jest convention is included.
- The standard browser suite was **not run successfully**: the local Ghostscript/ghostscript4js prerequisites documented in the README were missing. The direct browser checks do not establish a passing full browser suite.
- Targeted ESLint: no errors, three existing JSDoc warnings. Repository-wide lint still reports 18 errors and 128 warnings outside the changed lines. Node 20 was used because the default local Node rejected the build's existing JSON import assertions.
